### PR TITLE
fix: ensure Traefik network creation in Docker build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ And extra flag for cleaning files is also available: `--clean-before-tasks`.
 
 Then, run `make install` and profit.
 
+_N.B : Traefik required an external network. The `make install` command will try to create it if it not exists.
+But in case an error occured, you can try to create it manuelly with `docker network create traefik` (look in `docker-compose.override.yaml` to get the exact network name)._
+
 ## Tasks
 
 ```bash

--- a/infrastructure/docker/autoconf/Makefile.dist
+++ b/infrastructure/docker/autoconf/Makefile.dist
@@ -65,7 +65,7 @@ prettier: node_modules ## Watch the assets and build their development version o
 ##---------------------------------------------------------------------------
 .PHONY: rm-docker-dev.lock
 
-build: docker-dev.lock
+build: docker-network docker-dev.lock
 
 docker-dev.lock:
 	$(DOCKER_COMPOSE) pull --ignore-pull-failures
@@ -74,6 +74,12 @@ docker-dev.lock:
 
 rm-docker-dev.lock:
 	rm -f docker-dev.lock
+
+docker-network:
+	@network_name=$$($(DOCKER_COMPOSE) config | grep -B 1 'external: true' | grep -v 'external: true' | awk '{print $$2}'); \
+	if ! $(DOCKER) network inspect "$$network_name" >/dev/null 2>&1; then \
+		$(DOCKER) network create "$$network_name"; \
+	fi
 
 node_modules: package-lock.json
 	$(EXECJS) npm install


### PR DESCRIPTION
- Add a `docker-network` target to the Makefile to create the Traefik external network if it does not exist.
- Add ne xtarget to `install`
- Update the README to inform users about the network requirement and manual creation steps if necessary.

Closes Issue #47